### PR TITLE
Fix css hot reload

### DIFF
--- a/template/src/app/client-entry.js
+++ b/template/src/app/client-entry.js
@@ -1,3 +1,16 @@
 import {app} from '.';
 
 app.$mount('#app');
+
+// When Webpack builds css, this code will ensure that new styles will be shown in the browser.
+if (module.hot) {
+  const reporter = window.__webpack_hot_middleware_reporter__;
+  const success = reporter.success;
+  reporter.success = function () {
+    document.querySelectorAll('link[href][rel=stylesheet]').forEach((link) => {
+      const nextStyleHref = link.href.replace(/(\?\d+)?$/, `?${Date.now()}`);
+      link.href = nextStyleHref;
+    });
+    success();
+  };
+}


### PR DESCRIPTION
When Webpack built css and then extract css with ExtractTextPlugin, this change is not registered with 'webpack-hot-middleware'. This is normal behavior since  'webpack-hot-middleware' deals with hot JS module reload where css is expected to be an integral part of the JS module.

Therefore I made this proposal which provides an elegant solution for updating CSS style link with changing a timestamp as a query parameter every time when hotreload is succeeded.

Credits for this hack go to @drosen0 found in this [comment](https://github.com/webpack/extract-text-webpack-plugin/issues/30#issuecomment-256958209)