### PR TITLE
Improve middlewares order

### DIFF
--- a/template/src/server/index.js
+++ b/template/src/server/index.js
@@ -31,9 +31,9 @@ class Server {
       if (this.server) return this;
 
       this.app = express();
+      this.app.use('/', vueServer(this));
       this.app.use('/', publicServer(this));
       this.app.use('/', bundlesServer(this));
-      this.app.use('/', vueServer(this));
       this.app.use('/*', appServer(this));
 
       let {serverPort, serverHost} = this.config;


### PR DESCRIPTION
When you run 'npm run build' it creates 'dist' directory and if you change environment to 'production' with
```
npm config set vue-example:env production
```
then the app is served from this directory and not from inMemory 'dist' folder which is created by [express-vue-dev](https://github.com/xpepermint/express-vue-dev) via 'webpack-dev-middleware'.

However, if you change back to 'development' mode, the app is still served from 'dist' dir and you can't use hotreload features anymore.

The problem is in middlewares order, where 'bundlesServe' middleware should be used after 'vueServer'.

```
this.app.use('/', vueServer(this));
this.app.use('/', publicServer(this));
this.app.use('/', bundlesServer(this));
```