### PR TITLE
Add viewport meta tag

### DIFF
--- a/template/src/server/middlewares/app.js
+++ b/template/src/server/middlewares/app.js
@@ -50,6 +50,7 @@ exports.appServer = function ({settings}) {
       res.write(`<html lang="en">`);
       res.write(`<head>`);
       res.write(  `<meta charset="utf-8">`);
+      res.write(  `<meta name="viewport" content="width=device-width, initial-scale=1">`);
       res.write(  `<title>Example</title>`);
       res.write(  !isDev ? `<link href="${publicPath}bundle.css" rel='stylesheet' type='text/css'>` : '');
       res.write(`</head>`);


### PR DESCRIPTION
I recommend adding viewport meta tag in a middleware which renders the Vue.js application.